### PR TITLE
Add app label to everything

### DIFF
--- a/api/deployment_config.yaml
+++ b/api/deployment_config.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: DeploymentConfig
 metadata:
   name: topological-inventory-api
+  labels:
+    app: topological-inventory
 spec:
   replicas: 1
   selector:
@@ -10,6 +12,7 @@ spec:
     metadata:
       name: topological-inventory-api
       labels:
+        app: topological-inventory
         name: topological-inventory-api
     spec:
       containers:

--- a/api/secret.yaml
+++ b/api/secret.yaml
@@ -9,6 +9,8 @@ objects:
   kind: Secret
   metadata:
     name: topological-inventory-api-secrets
+    labels:
+      app: topological-inventory
   stringData:
     secret-key: "${SECRET_KEY}"
     encryption-key: "${ENCRYPTION_KEY}"

--- a/api/service.yaml
+++ b/api/service.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: topological-inventory-api
+  labels:
+    app: topological-inventory
 spec:
   ports:
   - name: topological-inventory-api

--- a/database/deployment_config.yaml
+++ b/database/deployment_config.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: DeploymentConfig
 metadata:
   name: topological-inventory-postgresql
+  labels:
+    app: topological-inventory
 spec:
   strategy:
     type: Recreate
@@ -15,6 +17,7 @@ spec:
       name: topological-inventory-postgresql
       labels:
         name: topological-inventory-postgresql
+        app: topological-inventory
     spec:
       volumes:
       - name: topological-inventory-postgresql

--- a/database/pvc.yaml
+++ b/database/pvc.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: topological-inventory-postgresql
+  labels:
+    app: topological-inventory
 spec:
   accessModes:
   - ReadWriteOnce

--- a/database/secret.yaml
+++ b/database/secret.yaml
@@ -9,6 +9,8 @@ objects:
   kind: Secret
   metadata:
     name: topological-inventory-database-secrets
+    labels:
+      app: topological-inventory
   stringData:
     database-password: "${DATABASE_PASSWORD}"
 parameters:

--- a/database/service.yaml
+++ b/database/service.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: topological-inventory-postgresql
+  labels:
+    app: topological-inventory
 spec:
   ports:
   - name: topological-inventory-postgresql

--- a/ingress-api/deployment_config.yaml
+++ b/ingress-api/deployment_config.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: DeploymentConfig
 metadata:
   name: topological-inventory-ingress-api
+  labels:
+    app: topological-inventory
 spec:
   replicas: 1
   selector:
@@ -11,6 +13,7 @@ spec:
       name: topological-inventory-ingress-api
       labels:
         name: topological-inventory-ingress-api
+        app: topological-inventory
     spec:
       containers:
       - name: topological-inventory-ingress-api

--- a/ingress-api/service.yaml
+++ b/ingress-api/service.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: topological-inventory-ingress-api
+  labels:
+    app: topological-inventory
 spec:
   ports:
   - name: topological-inventory-ingress-api

--- a/persister/deployment_config.yaml
+++ b/persister/deployment_config.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: DeploymentConfig
 metadata:
   name: topological-inventory-persister
+  labels:
+    app: topological-inventory
 spec:
   replicas: 1
   selector:
@@ -11,6 +13,7 @@ spec:
       name: topological-inventory-persister
       labels:
         name: topological-inventory-persister
+        app: topological-inventory
     spec:
       containers:
       - name: topological-inventory-persister

--- a/queue/deployment_config.yaml
+++ b/queue/deployment_config.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: DeploymentConfig
 metadata:
   name: topological-inventory-kafka
+  labels:
+    app: topological-inventory
 spec:
   replicas: 1
   selector:
@@ -11,6 +13,7 @@ spec:
       name: topological-inventory-kafka
       labels:
         name: topological-inventory-kafka
+        app: topological-inventory
     spec:
       containers:
       - name: topological-inventory-kafka

--- a/queue/service.yaml
+++ b/queue/service.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: topological-inventory-kafka
+  labels:
+    app: topological-inventory
 spec:
   ports:
   - name: topological-inventory-kafka

--- a/teardown
+++ b/teardown
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+oc delete all -l app=topological-inventory
+
+oc get pvc -o name |xargs oc delete
+
+oc delete secret -l app=topological-inventory


### PR DESCRIPTION
Everything relating to our application is now labeled with `app=topological-inventory`

This will make things display a bit better in the OpenShift web UI as well as give us an easier way to reference all of the objects at once.

The first usecase for this would be the teardown script which was also added in this PR.