### PR TITLE
Change the api service port to 8080

### DIFF
--- a/api/service.yaml
+++ b/api/service.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   ports:
   - name: topological-inventory-api
-    port: 3000
+    port: 8080
+    targetPort: 3000
   selector:
     name: topological-inventory-api


### PR DESCRIPTION
All the internal insights services seem to be running on 8080
We will still use 3000 internal to the pod