### PR TITLE
Add the DATABASE_URL as an environment variable to deployment configs

### DIFF
--- a/api/deploy_template.yaml
+++ b/api/deploy_template.yaml
@@ -41,19 +41,15 @@ objects:
           env:
           - name: APP_NAME
             value: ${APP_NAME}
-          - name: DATABASE_USER
-            value: root
-          - name: DATABASE_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: topological-inventory-database-secrets
-                key: database-password
-          - name: DATABASE_NAME
-            value: topological_inventory_production
           - name: DATABASE_HOST
             value: topological-inventory-postgresql
           - name: DATABASE_PORT
             value: "5432"
+          - name: DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                name: topological-inventory-database-secrets
+                key: database-url
           - name: PATH_PREFIX
             value: ${PATH_PREFIX}
           - name: SECRET_KEY_BASE

--- a/database/secret_template.yaml
+++ b/database/secret_template.yaml
@@ -13,6 +13,7 @@ objects:
       app: topological-inventory
   stringData:
     database-password: "${DATABASE_PASSWORD}"
+    database-url: postgresql://root:${DATABASE_PASSWORD}@topological-inventory-postgresql:5432/topological_inventory_production?encoding=utf8&pool=5&wait_timeout=5
 parameters:
 - name: DATABASE_PASSWORD
   displayName: PostgreSQL Password

--- a/ingress-api/deploy_template.yaml
+++ b/ingress-api/deploy_template.yaml
@@ -42,19 +42,15 @@ objects:
             tcpSocket:
               port: 3000
           env:
-          - name: DATABASE_USER
-            value: root
-          - name: DATABASE_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: topological-inventory-database-secrets
-                key: database-password
-          - name: DATABASE_NAME
-            value: topological_inventory_production
           - name: DATABASE_HOST
             value: topological-inventory-postgresql
           - name: DATABASE_PORT
             value: "5432"
+          - name: DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                name: topological-inventory-database-secrets
+                key: database-url
           - name: SECRET_KEY_BASE
             valueFrom:
               secretKeyRef:

--- a/persister/deploy_template.yaml
+++ b/persister/deploy_template.yaml
@@ -24,19 +24,15 @@ objects:
         - name: topological-inventory-persister
           image: ${IMAGE_NAMESPACE}/topological-inventory-persister:latest
           env:
-          - name: DATABASE_USER
-            value: root
-          - name: DATABASE_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: topological-inventory-database-secrets
-                key: database-password
-          - name: DATABASE_NAME
-            value: topological_inventory_production
           - name: DATABASE_HOST
             value: topological-inventory-postgresql
           - name: DATABASE_PORT
             value: "5432"
+          - name: DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                name: topological-inventory-database-secrets
+                key: database-url
           - name: ENCRYPTION_KEY
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
The URL value will be stored as an entry in the database's secret
object and imported by the deployment configs that need it.

This removes the need to pass in the database user, name, and password
to each individual deployment. The host and port need to remain
so that these pods can wait for the database service to be available

https://projects.engineering.redhat.com/browse/TPINVTRY-137