### PR TITLE
Add a 500Mi resource limit to the persister container

### DIFF
--- a/persister/deploy_template.yaml
+++ b/persister/deploy_template.yaml
@@ -23,6 +23,9 @@ objects:
         containers:
         - name: topological-inventory-persister
           image: ${IMAGE_NAMESPACE}/topological-inventory-persister:latest
+          resources:
+            limits:
+              memory: 500Mi
           env:
           - name: DATABASE_HOST
             value: topological-inventory-postgresql


### PR DESCRIPTION
In the dev cluster a default limit of 200Mi is put on all containers
this is too low for the persister so we need to specify a higher
limit to change it.