### PR TITLE
Add the "no cache" option to the api and persister builds

### DIFF
--- a/api/build_template.yaml
+++ b/api/build_template.yaml
@@ -16,6 +16,8 @@ objects:
         uri: ${SOURCE_REPOSITORY_URL}
         ref: ${SOURCE_REPOSITORY_REF}
     strategy:
+      dockerStrategy:
+        noCache: true
       type: Docker
     output:
       to:

--- a/persister/build_template.yaml
+++ b/persister/build_template.yaml
@@ -16,6 +16,8 @@ objects:
         uri: ${SOURCE_REPOSITORY_URL}
         ref: ${SOURCE_REPOSITORY_REF}
     strategy:
+      dockerStrategy:
+        noCache: true
       type: Docker
     output:
       to:


### PR DESCRIPTION
This is needed to pick up the newest core engine changes when
running a new build.

To truly have the most up-to-date image, we should also trigger
the persister and api builds when we merge to core.