### PR TITLE
Add build and deploy templates for openshift operations

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -19,5 +19,5 @@ oc start-build topological-inventory-amazon-collector
 oc start-build topological-inventory-api
 oc start-build topological-inventory-ingress-api
 oc start-build topological-inventory-mock-collector
-oc start-build topological-inventory-openshift-collector
+oc start-build topological-inventory-openshift
 oc start-build topological-inventory-persister

--- a/bin/deploy
+++ b/bin/deploy
@@ -36,3 +36,4 @@ oc apply -f database/deployment_config.yaml
 apply_template "api/deploy_template.yaml"
 apply_template "ingress-api/deploy_template.yaml"
 apply_template "persister/deploy_template.yaml"
+apply_Template "openshift-operations/deploy_template.yaml"

--- a/openshift-collector/build_template.yaml
+++ b/openshift-collector/build_template.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: Template
 labels:
-  template: topological-inventory-openshift-collector-build
+  template: topological-inventory-openshift-build
 metadata:
-  name: topological-inventory-openshift-collector-build
+  name: topological-inventory-openshift-build
 objects:
 - apiVersion: v1
   kind: BuildConfig
   metadata:
-    name: topological-inventory-openshift-collector
+    name: topological-inventory-openshift
   spec:
     source:
       type: Git
@@ -23,7 +23,7 @@ objects:
     output:
       to:
         kind: ImageStreamTag
-        name: topological-inventory-openshift-collector:latest
+        name: topological-inventory-openshift:latest
         namespace: ${IMAGE_NAMESPACE}
     triggers:
     - type: GitHub
@@ -32,7 +32,7 @@ objects:
 - apiVersion: v1
   kind: ImageStream
   metadata:
-    name: topological-inventory-openshift-collector
+    name: topological-inventory-openshift
   spec:
     tags:
     - name: latest

--- a/openshift-collector/deploy_template.yaml
+++ b/openshift-collector/deploy_template.yaml
@@ -32,7 +32,7 @@ objects:
       spec:
         containers:
         - name: topological-inventory-openshift-collector-${SOURCE_ID}
-          image: ${IMAGE_NAMESPACE}/topological-inventory-openshift-collector:latest
+          image: ${IMAGE_NAMESPACE}/topological-inventory-openshift:latest
           env:
           - name: INGRESS_API
             value: http://${INGRESS_SERVICE_HOST}:${INGRESS_SERVICE_PORT}
@@ -56,7 +56,7 @@ objects:
             - topological-inventory-openshift-collector-${SOURCE_ID}
           from:
             kind: ImageStreamTag
-            name: topological-inventory-openshift-collector:latest
+            name: topological-inventory-openshift:latest
             namespace: ${IMAGE_NAMESPACE}
 parameters:
 - name: IMAGE_NAMESPACE

--- a/openshift-operations/deploy_template.yaml
+++ b/openshift-operations/deploy_template.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: Template
+labels:
+  template: topological-inventory-openshift-operations
+metadata:
+  name: topological-inventory-openshift-operations
+objects:
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    name: topological-inventory-openshift-operations
+    labels:
+      app: topological-inventory
+  spec:
+    replicas: 1
+    selector:
+      name: topological-inventory-openshift-operations
+    template:
+      metadata:
+        name: topological-inventory-openshift-operations
+        labels:
+          name: topological-inventory-openshift-operations
+          app: topological-inventory
+      spec:
+        containers:
+        - name: topological-inventory-openshift-operations
+          image: ${IMAGE_NAMESPACE}/topological-inventory-openshift:latest
+          command:
+          - bin/openshift-operations
+          env:
+          - name: QUEUE_HOST
+            value: ${QUEUE_HOST}
+          - name: QUEUE_PORT
+            value: "9092"
+    triggers:
+      - type: ConfigChange
+      - type: ImageChange
+        imageChangeParams:
+          automatic: true
+          containerNames:
+            - topological-inventory-openshift-operations
+          from:
+            kind: ImageStreamTag
+            name: topological-inventory-openshift:latest
+            namespace: ${IMAGE_NAMESPACE}
+parameters:
+- name: IMAGE_NAMESPACE
+  displayName: Image Namespace
+  description: Namespace which contains the image stream to pull from
+  value: buildfactory
+- name: QUEUE_HOST
+  displayName: Message Queue Hostname
+  description: Hostname which will be used to contact the message queue.
+  required: true


### PR DESCRIPTION
~~This is not added to the deployment script as the intention
is for this to be deployed by the orchestrator.~~

We are going to deploy this unconditionally and maybe do some dynamic scaling in the future. Not having any openshift source at all is too unrealistic a condition to add a who new section to the orchestrator.

This also renames the image for the openshift collector and shares it across the two deployments. The operations worker overrides the entrypoint.

@agrare @eclarizio Let me know what you think about the environment variables and if you think we need anything else.