### PR TITLE
Add source ids to collector object names

### DIFF
--- a/amazon-collector/deploy_template.yaml
+++ b/amazon-collector/deploy_template.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: Template
 labels:
-  template: topological-inventory-amazon-collector
+  template: topological-inventory-amazon-collector-${SOURCE_ID}
 metadata:
-  name: topological-inventory-amazon-collector
+  name: topological-inventory-amazon-collector-${SOURCE_ID}
 objects:
 - apiVersion: v1
   kind: Secret
   metadata:
-    name: topological-inventory-amazon-collector-secrets
+    name: topological-inventory-amazon-collector-secrets-${SOURCE_ID}
     labels:
       app: topological-inventory
   stringData:
@@ -17,35 +17,35 @@ objects:
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
-    name: topological-inventory-amazon-collector
+    name: topological-inventory-amazon-collector-${SOURCE_ID}
     labels:
       app: topological-inventory
   spec:
     replicas: 1
     selector:
-      name: topological-inventory-amazon-collector
+      name: topological-inventory-amazon-collector-${SOURCE_ID}
     template:
       metadata:
-        name: topological-inventory-amazon-collector
+        name: topological-inventory-amazon-collector-${SOURCE_ID}
         labels:
-          name: topological-inventory-amazon-collector
+          name: topological-inventory-amazon-collector-${SOURCE_ID}
           app: topological-inventory
       spec:
         containers:
-        - name: topological-inventory-amazon-collector
+        - name: topological-inventory-amazon-collector-${SOURCE_ID}
           image: ${IMAGE_NAMESPACE}/topological-inventory-amazon-collector:latest
           env:
           - name: ACCESS_KEY_ID
             valueFrom:
               secretKeyRef:
-                name: topological-inventory-amazon-collector-secrets
+                name: topological-inventory-amazon-collector-secrets-${SOURCE_ID}
                 key: access-key-id
           - name: INGRESS_API
             value: http://${INGRESS_SERVICE_HOST}:${INGRESS_SERVICE_PORT}
           - name: SECRET_ACCESS_KEY
             valueFrom:
               secretKeyRef:
-                name: topological-inventory-amazon-collector-secrets
+                name: topological-inventory-amazon-collector-secrets-${SOURCE_ID}
                 key: secret-access-key
           - name: SOURCE_UID
             value: ${SOURCE_UID}
@@ -55,7 +55,7 @@ objects:
         imageChangeParams:
           automatic: true
           containerNames:
-            - topological-inventory-amazon-collector
+            - topological-inventory-amazon-collector-${SOURCE_ID}
           from:
             kind: ImageStreamTag
             name: topological-inventory-amazon-collector:latest
@@ -82,6 +82,10 @@ parameters:
 - name: SECRET_ACCESS_KEY
   displayName: Amazon Access Key Secret
   description: Amazon account acces key secret
+  required: true
+- name: SOURCE_ID
+  displayName: Source ID
+  description: Source id to differentiate between different instances
   required: true
 - name: SOURCE_UID
   displayName: Source UID

--- a/openshift-collector/deploy_template.yaml
+++ b/openshift-collector/deploy_template.yaml
@@ -3,12 +3,12 @@ kind: Template
 labels:
   template: topological-inventory-openshift-collector
 metadata:
-  name: topological-inventory-openshift-collector
+  name: topological-inventory-openshift-collector-${SOURCE_ID}
 objects:
 - apiVersion: v1
   kind: Secret
   metadata:
-    name: topological-inventory-openshift-collector-secrets
+    name: topological-inventory-openshift-collector-secrets-${SOURCE_ID}
     labels:
       app: topological-inventory
   stringData:
@@ -16,22 +16,22 @@ objects:
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
-    name: topological-inventory-openshift-collector
+    name: topological-inventory-openshift-collector-${SOURCE_ID}
     labels:
       app: topological-inventory
   spec:
     replicas: 1
     selector:
-      name: topological-inventory-openshift-collector
+      name: topological-inventory-openshift-collector-${SOURCE_ID}
     template:
       metadata:
-        name: topological-inventory-openshift-collector
+        name: topological-inventory-openshift-collector-${SOURCE_ID}
         labels:
-          name: topological-inventory-openshift-collector
+          name: topological-inventory-openshift-collector-${SOURCE_ID}
           app: topological-inventory
       spec:
         containers:
-        - name: topological-inventory-openshift-collector
+        - name: topological-inventory-openshift-collector-${SOURCE_ID}
           image: ${IMAGE_NAMESPACE}/topological-inventory-openshift-collector:latest
           env:
           - name: INGRESS_API
@@ -41,7 +41,7 @@ objects:
           - name: OPENSHIFT_TOKEN
             valueFrom:
               secretKeyRef:
-                name: topological-inventory-openshift-collector-secrets
+                name: topological-inventory-openshift-collector-secrets-${SOURCE_ID}
                 key: openshift-token
           - name: SOURCE_UID
             value: ${SOURCE_UID}
@@ -51,7 +51,7 @@ objects:
         imageChangeParams:
           automatic: true
           containerNames:
-            - topological-inventory-openshift-collector
+            - topological-inventory-openshift-collector-${SOURCE_ID}
           from:
             kind: ImageStreamTag
             name: topological-inventory-openshift-collector:latest
@@ -79,6 +79,10 @@ parameters:
   displayName: OpenShift Cluster Token
   required: true
   description: Token to use to authenticate to the OpenShift Host
+- name: SOURCE_ID
+  displayName: Source ID
+  required: true
+  description: Source id to differentiate between different instances
 - name: SOURCE_UID
   displayName: Source UID
   required: true


### PR DESCRIPTION
This will allow us to deploy multiple instances of a collector for a particular collector type.