### PR TITLE
Add the kafka queue host and port to the api deployment

### DIFF
--- a/api/deploy_template.yaml
+++ b/api/deploy_template.yaml
@@ -66,6 +66,10 @@ objects:
               secretKeyRef:
                 name: topological-inventory-api-secrets
                 key: encryption-key
+          - name: QUEUE_HOST
+            value: ${QUEUE_HOST}
+          - name: QUEUE_PORT
+            value: "9092"
           readinessProbe:
             tcpSocket:
               port: 3000
@@ -95,3 +99,7 @@ parameters:
 - name: PATH_PREFIX
   displayName: Path Prefix
   description: Base path for the API
+- name: QUEUE_HOST
+  displayName: Message Queue Hostname
+  description: Hostname which will be used to contact the message queue.
+  required: true


### PR DESCRIPTION
This will be used to queue operations messages

Merge before https://github.com/ManageIQ/topological_inventory-api/pull/103

cc @eclarizio 