### PR TITLE
Use noCache strategy for collectors

### DIFF
--- a/amazon-collector/build_template.yaml
+++ b/amazon-collector/build_template.yaml
@@ -19,6 +19,8 @@ objects:
       limits:
         memory: 1Gi
     strategy:
+      dockerStrategy:
+        noCache: true
       type: Docker
     output:
       to:

--- a/openshift-collector/build_template.yaml
+++ b/openshift-collector/build_template.yaml
@@ -19,6 +19,8 @@ objects:
       limits:
         memory: 1Gi
     strategy:
+      dockerStrategy:
+        noCache: true
       type: Docker
     output:
       to:


### PR DESCRIPTION
We don't version the ingress_api-client yet so we need to use noCache
to pull in the latest version when building the collectors.