### PR TITLE
Add resource limits and requests

### DIFF
--- a/api/deploy_template.yaml
+++ b/api/deploy_template.yaml
@@ -75,7 +75,11 @@ objects:
               port: 3000
           resources:
             limits:
+              cpu: 200m
               memory: 1Gi
+            requests:
+              cpu: 50m
+              memory: 500Mi
     triggers:
       - type: ConfigChange
       - type: ImageChange

--- a/database/deployment_config.yaml
+++ b/database/deployment_config.yaml
@@ -41,3 +41,10 @@ spec:
               key: database-password
         - name: POSTGRESQL_DATABASE
           value: topological_inventory_production
+        resources:
+          limits:
+            cpu: 200m
+            memory: 500Mi
+          requests:
+            cpu: 50m
+            memory: 200Mi

--- a/ingress-api/deploy_template.yaml
+++ b/ingress-api/deploy_template.yaml
@@ -71,6 +71,10 @@ objects:
             value: "9092"
           resources:
             limits:
+              cpu: 200m
+              memory: 1Gi
+            requests:
+              cpu: 50m
               memory: 500Mi
     triggers:
       - type: ConfigChange

--- a/openshift-operations/deploy_template.yaml
+++ b/openshift-operations/deploy_template.yaml
@@ -32,6 +32,13 @@ objects:
             value: ${QUEUE_HOST}
           - name: QUEUE_PORT
             value: "9092"
+          resources:
+            limits:
+              cpu: 200m
+              memory: 200Mi
+            requests:
+              cpu: 50m
+              memory: 100Mi
     triggers:
       - type: ConfigChange
       - type: ImageChange

--- a/orchestrator/deploy_template.yaml
+++ b/orchestrator/deploy_template.yaml
@@ -34,6 +34,13 @@ objects:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          resources:
+            limits:
+              cpu: 100m
+              memory: 200Mi
+            requests:
+              cpu: 25m
+              memory: 100Mi
         serviceAccountName: topological-inventory-orchestrator
     triggers:
       - type: ConfigChange

--- a/persister/deploy_template.yaml
+++ b/persister/deploy_template.yaml
@@ -23,9 +23,6 @@ objects:
         containers:
         - name: topological-inventory-persister
           image: ${IMAGE_NAMESPACE}/topological-inventory-persister:latest
-          resources:
-            limits:
-              memory: 500Mi
           env:
           - name: DATABASE_HOST
             value: topological-inventory-postgresql
@@ -45,6 +42,13 @@ objects:
             value: ${QUEUE_HOST}
           - name: QUEUE_PORT
             value: "9092"
+          resources:
+            limits:
+              cpu: 200m
+              memory: 1Gi
+            requests:
+              cpu: 50m
+              memory: 500Mi
     triggers:
       - type: ConfigChange
       - type: ImageChange


### PR DESCRIPTION
These more closely resemble the actual resource usage of our
deployments and will also allow us to more accurately report
usage to the project quota.

Currently every pod is getting a default request of 200m for CPU
and 100Mi for memory which is effectively restricting us to a
maximum pod count of 10 as our max request for cpu is 2 cores\

@agrare @bdunne what do you think of these values?