### PR TITLE
Minimum value for CPU is 100m so don't request less

### DIFF
--- a/api/deploy_template.yaml
+++ b/api/deploy_template.yaml
@@ -78,7 +78,7 @@ objects:
               cpu: 200m
               memory: 1Gi
             requests:
-              cpu: 50m
+              cpu: 100m
               memory: 500Mi
     triggers:
       - type: ConfigChange

--- a/database/deployment_config.yaml
+++ b/database/deployment_config.yaml
@@ -46,5 +46,5 @@ spec:
             cpu: 200m
             memory: 500Mi
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 200Mi

--- a/ingress-api/deploy_template.yaml
+++ b/ingress-api/deploy_template.yaml
@@ -74,7 +74,7 @@ objects:
               cpu: 200m
               memory: 1Gi
             requests:
-              cpu: 50m
+              cpu: 100m
               memory: 500Mi
     triggers:
       - type: ConfigChange

--- a/openshift-operations/deploy_template.yaml
+++ b/openshift-operations/deploy_template.yaml
@@ -37,7 +37,7 @@ objects:
               cpu: 200m
               memory: 200Mi
             requests:
-              cpu: 50m
+              cpu: 100m
               memory: 100Mi
     triggers:
       - type: ConfigChange

--- a/orchestrator/deploy_template.yaml
+++ b/orchestrator/deploy_template.yaml
@@ -39,7 +39,7 @@ objects:
               cpu: 100m
               memory: 200Mi
             requests:
-              cpu: 25m
+              cpu: 100m
               memory: 100Mi
         serviceAccountName: topological-inventory-orchestrator
     triggers:

--- a/persister/deploy_template.yaml
+++ b/persister/deploy_template.yaml
@@ -47,7 +47,7 @@ objects:
               cpu: 200m
               memory: 1Gi
             requests:
-              cpu: 50m
+              cpu: 100m
               memory: 500Mi
     triggers:
       - type: ConfigChange


### PR DESCRIPTION
Previously we were getting errors like:

Error creating: pods "topological-inventory-openshift-operations-5-bjwlq"
is forbidden: minimum cpu usage per Pod is 100m, but request is 50m.