### PR TITLE
Use the PG 10 scl image rather than ours

### DIFF
--- a/database/deployment_config.yaml
+++ b/database/deployment_config.yaml
@@ -25,7 +25,7 @@ spec:
           claimName: topological-inventory-postgresql
       containers:
       - name: topological-inventory-postgresql
-        image: docker.io/manageiq/postgresql:latest
+        image: docker.io/centos/postgresql-10-centos7:latest
         ports:
         - containerPort: 5432
         volumeMounts:


### PR DESCRIPTION
The only thing our image was gaining us was `SUPERUSER` permissions and backup and restore scripts which we don't need anymore.