### PR TITLE
Change the template name for the orchestrator

### DIFF
--- a/orchestrator/deploy_template.yaml
+++ b/orchestrator/deploy_template.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: topological-inventory-ingress-api
+  name: topological-inventory-orchestrator
 objects:
 - apiVersion: v1
   kind: DeploymentConfig


### PR DESCRIPTION
This wouldn't actually make it to the cluster as we `oc process`
before we tell the cluster to deploy anything, but we should still
fix it anyway