### PR TITLE
Copy the database secret format from production

### DIFF
--- a/api/deploy_template.yaml
+++ b/api/deploy_template.yaml
@@ -46,14 +46,22 @@ objects:
           - name: APP_NAME
             value: ${APP_NAME}
           - name: DATABASE_HOST
-            value: topological-inventory-postgresql
-          - name: DATABASE_PORT
-            value: "5432"
-          - name: DATABASE_URL
             valueFrom:
               secretKeyRef:
-                name: topological-inventory-database-secrets
-                key: database-url
+                name: topological-inventory-db
+                key: hostname
+          - name: DATABASE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: topological-inventory-db
+                key: password
+          - name: DATABASE_PORT
+            value: "5432"
+          - name: DATABASE_USER
+            valueFrom:
+              secretKeyRef:
+                name: topological-inventory-db
+                key: username
           - name: PATH_PREFIX
             value: ${PATH_PREFIX}
           - name: SECRET_KEY_BASE

--- a/bin/deploy
+++ b/bin/deploy
@@ -24,7 +24,7 @@ function api_secrets_provided() {
 # For us to safely create the secret we need to have either provided a password
 # or not have created the secret yet. This ensures we don't overwrite the existing
 # password with a newly generated one.
-(database_password_provided || secret_missing "topological-inventory-database-secrets") && apply_template "database/secret_template.yaml"
+(database_password_provided || secret_missing "topological-inventory-db") && apply_template "database/secret_template.yaml"
 (api_secrets_provided || secret_missing "topological-inventory-api-secrets") && apply_template "api/secret_template.yaml"
 
 # database

--- a/database/deployment_config.yaml
+++ b/database/deployment_config.yaml
@@ -33,12 +33,15 @@ spec:
           mountPath: "/var/lib/pgsql/data"
         env:
         - name: POSTGRESQL_USER
-          value: root
+          valueFrom:
+            secretKeyRef:
+              name: topological-inventory-db
+              key: username
         - name: POSTGRESQL_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: topological-inventory-database-secrets
-              key: database-password
+              name: topological-inventory-db
+              key: password
         - name: POSTGRESQL_DATABASE
           value: topological_inventory_production
         resources:

--- a/database/secret_template.yaml
+++ b/database/secret_template.yaml
@@ -8,12 +8,13 @@ objects:
 - apiVersion: v1
   kind: Secret
   metadata:
-    name: topological-inventory-database-secrets
+    name: topological-inventory-db
     labels:
       app: topological-inventory
   stringData:
-    database-password: "${DATABASE_PASSWORD}"
-    database-url: postgresql://root:${DATABASE_PASSWORD}@topological-inventory-postgresql:5432/topological_inventory_production?encoding=utf8&pool=5&wait_timeout=5
+    hostname: topological-inventory-postgresql
+    password: "${DATABASE_PASSWORD}"
+    username: root
 parameters:
 - name: DATABASE_PASSWORD
   displayName: PostgreSQL Password

--- a/persister/deploy_template.yaml
+++ b/persister/deploy_template.yaml
@@ -25,14 +25,22 @@ objects:
           image: ${IMAGE_NAMESPACE}/topological-inventory-persister:latest
           env:
           - name: DATABASE_HOST
-            value: topological-inventory-postgresql
-          - name: DATABASE_PORT
-            value: "5432"
-          - name: DATABASE_URL
             valueFrom:
               secretKeyRef:
-                name: topological-inventory-database-secrets
-                key: database-url
+                name: topological-inventory-db
+                key: hostname
+          - name: DATABASE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: topological-inventory-db
+                key: password
+          - name: DATABASE_PORT
+            value: "5432"
+          - name: DATABASE_USER
+            valueFrom:
+              secretKeyRef:
+                name: topological-inventory-db
+                key: username
           - name: ENCRYPTION_KEY
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
This is needed to ensure that we don't need to change
our deployment configs between CI and PROD environments