### PR TITLE
Splitted config params for mock source

### DIFF
--- a/mock-collector/deployment_config_template.yaml
+++ b/mock-collector/deployment_config_template.yaml
@@ -32,6 +32,8 @@ objects:
             value: http://${INGRESS_SERVICE_HOST}:${INGRESS_SERVICE_PORT}
           - name: SOURCE_UID
             value: ${SOURCE_UID}
+          - name: AMOUNTS
+            value: ${AMOUNTS_CONFIG_NAME}
     triggers:
       - type: ConfigChange
       - type: ImageChange
@@ -48,6 +50,11 @@ parameters:
   displayName: Config File Name
   required: true
   description: Config File to use for the mock collector
+  value: default
+- name: AMOUNTS_CONFIG_NAME
+  displayName: Amounts config file name
+  required: true
+  description: Config file with requested amounts of data
   value: default
 - name: IMAGE_NAMESPACE
   displayName: Image Namespace


### PR DESCRIPTION
Mock Source:
According to PR https://github.com/ManageIQ/topological_inventory-mock_source/pull/12/files 
There are two config files: one for generator settings and second for generated amounts of data.

@carbonin please review