### PR TITLE
Mock Collector renamed to Mock Source

### DIFF
--- a/mock-collector/build_template.yaml
+++ b/mock-collector/build_template.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: Template
 labels:
-  template: topological-inventory-mock-collector-build
+  template: topological-inventory-mock-source-build
 metadata:
-  name: topological-inventory-mock-collector-build
+  name: topological-inventory-mock-source-build
 objects:
 - apiVersion: v1
   kind: BuildConfig
   metadata:
-    name: topological-inventory-mock-collector
+    name: topological-inventory-mock-source
   spec:
     source:
       type: Git
@@ -23,7 +23,7 @@ objects:
     output:
       to:
         kind: ImageStreamTag
-        name: topological-inventory-mock-collector:latest
+        name: topological-inventory-mock-source:latest
         namespace: ${IMAGE_NAMESPACE}
     triggers:
     - type: GitHub
@@ -32,7 +32,7 @@ objects:
 - apiVersion: v1
   kind: ImageStream
   metadata:
-    name: topological-inventory-mock-collector
+    name: topological-inventory-mock-source
   spec:
     tags:
     - name: latest
@@ -50,7 +50,7 @@ parameters:
   description: The URL of the repository with your application source code.
   displayName: Git repository URI
   required: true
-  value: https://github.com/ManageIQ/topological_inventory-collector-mock
+  value: https://github.com/ManageIQ/topological_inventory-mock_source
 - name: SOURCE_REPOSITORY_REF
   description: Git repository branch to check out, if different from default
   displayName: Git Reference

--- a/mock-collector/deployment_config_template.yaml
+++ b/mock-collector/deployment_config_template.yaml
@@ -1,30 +1,30 @@
 apiVersion: v1
 kind: Template
 labels:
-  template: topological-inventory-mock-collector
+  template: topological-inventory-mock-source
 metadata:
-  name: topological-inventory-mock-collector
+  name: topological-inventory-mock-source
 objects:
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
-    name: topological-inventory-mock-collector
+    name: topological-inventory-mock-source
     labels:
       app: topological-inventory
   spec:
     replicas: 1
     selector:
-      name: topological-inventory-mock-collector
+      name: topological-inventory-mock-source
     template:
       metadata:
-        name: topological-inventory-mock-collector
+        name: topological-inventory-mock-source
         labels:
-          name: topological-inventory-mock-collector
+          name: topological-inventory-mock-source
           app: topological-inventory
       spec:
         containers:
-        - name: topological-inventory-mock-collector
-          image: ${IMAGE_NAMESPACE}/topological-inventory-mock-collector:latest
+        - name: topological-inventory-mock-source
+          image: ${IMAGE_NAMESPACE}/topological-inventory-mock-source:latest
           env:
           - name: CONFIG
             value: ${CONFIG_NAME}
@@ -32,18 +32,18 @@ objects:
             value: http://${INGRESS_SERVICE_HOST}:${INGRESS_SERVICE_PORT}
           - name: SOURCE_UID
             value: ${SOURCE_UID}
-          - name: AMOUNTS
-            value: ${AMOUNTS_CONFIG_NAME}
+          - name: DATA
+            value: ${DATA_CONFIG_NAME}
     triggers:
       - type: ConfigChange
       - type: ImageChange
         imageChangeParams:
           automatic: true
           containerNames:
-            - topological-inventory-mock-collector
+            - topological-inventory-mock-source
           from:
             kind: ImageStreamTag
-            name: topological-inventory-mock-collector:latest
+            name: topological-inventory-mock-source:latest
             namespace: ${IMAGE_NAMESPACE}
 parameters:
 - name: CONFIG_NAME
@@ -51,8 +51,8 @@ parameters:
   required: true
   description: Config File to use for the mock collector
   value: default
-- name: AMOUNTS_CONFIG_NAME
-  displayName: Amounts config file name
+- name: DATA_CONFIG_NAME
+  displayName: Data config file name
   required: true
   description: Config file with requested amounts of data
   value: default


### PR DESCRIPTION
Mock Collector templates renamed to MockSource

Also `amounts` param renamed to `data`

---

- [ ] https://github.com/ManageIQ/topological_inventory-mock_source/pull/23